### PR TITLE
Fix coloring "1.2i" as numeric

### DIFF
--- a/MuPAD.tmLanguage
+++ b/MuPAD.tmLanguage
@@ -155,7 +155,7 @@
       </dict>
       <dict>
         <key>match</key>
-        <string>\b(([0-9]+\.?[0-9]*)((e|E)(\+|-)?[0-9]+)?)\b</string>
+        <string>\b(([0-9]+\.?[0-9]*)((e|E)(\+|-)?[0-9]+)?[ij]?)\b</string>
         <key>name</key>
         <string>constant.numeric.mupad</string>
       </dict>


### PR DESCRIPTION
Change the MuPAD syntax highlighting rules for numeric to also match 1.2i.